### PR TITLE
Implement non-volatile status condition: burn

### DIFF
--- a/pokemon_rust/src/battle/tests/core.rs
+++ b/pokemon_rust/src/battle/tests/core.rs
@@ -200,3 +200,24 @@ fn deals_damage_to_burned_pokemon() {
     let events = backend.process_turn("FirePunch", "Harden");
     assert_event!(events[5], Damage { target: 1, .. });
 }
+
+#[test]
+fn halves_physical_damage_of_burned_pokemon() {
+    let mut backend = battle! {
+        "Hitmonchan" 36 (max ivs, Serious) vs "Krabby" 36 (max ivs, Serious)
+    };
+
+    let turn1 = backend.process_turn("FirePunch", "Slam");
+    test_rng_mut!(backend.rng).force_secondary_effect(1);
+    let turn2 = backend.process_turn("FirePunch", "Slam");
+
+    match (&turn1[3], &turn2[4]) {
+        (
+            BattleEvent::Damage(Damage { amount: a1, .. }),
+            BattleEvent::Damage(Damage { amount: a2, .. }),
+        ) => {
+            assert_eq!(*a2, *a1 / 2);
+        },
+        _ => panic!("Pattern mismatch"),
+    }
+}

--- a/pokemon_rust/src/battle/tests/core.rs
+++ b/pokemon_rust/src/battle/tests/core.rs
@@ -189,3 +189,14 @@ fn makes_confusion_expire() {
         ..
     });
 }
+
+#[test]
+fn deals_damage_to_burned_pokemon() {
+    let mut backend = battle! {
+        "Hitmonchan" 24 (max ivs, Serious) vs "Krabby" 24 (max ivs, Serious)
+    };
+
+    test_rng_mut!(backend.rng).force_secondary_effect(1);
+    let events = backend.process_turn("FirePunch", "Harden");
+    assert_event!(events[5], Damage { target: 1, .. });
+}

--- a/pokemon_rust/src/battle/tests/moves/fire_punch.rs
+++ b/pokemon_rust/src/battle/tests/moves/fire_punch.rs
@@ -1,0 +1,22 @@
+use crate::{
+    battle::backend::BattleEvent,
+    pokemon::StatusCondition,
+};
+
+use super::super::{prelude::*, TestMethods};
+
+#[test]
+fn fire_punch_deals_damage_and_might_burn() {
+    let mut backend = battle! {
+        "Hitmonchan" 24 (max ivs, Serious) vs "Krabby" 24 (max ivs, Serious)
+    };
+
+    let turn1 = backend.process_turn("FirePunch", "Harden");
+    assert_event!(turn1[1], Damage { target: 1, is_critical_hit: false, .. });
+    assert_eq!(backend.get_pokemon(1).status_condition, None);
+
+    test_rng_mut!(backend.rng).force_secondary_effect(1);
+    let turn2 = backend.process_turn("FirePunch", "Harden");
+    assert_event!(turn2[1], Damage { target: 1, is_critical_hit: false, .. });
+    assert_eq!(backend.get_pokemon(1).status_condition, Some(StatusCondition::Burn));
+}

--- a/pokemon_rust/src/battle/tests/moves/mod.rs
+++ b/pokemon_rust/src/battle/tests/moves/mod.rs
@@ -6,6 +6,7 @@ mod double_kick;
 mod double_slap;
 mod drill_peck;
 mod egg_bomb;
+mod fire_punch;
 mod fissure;
 mod growl;
 mod guillotine;

--- a/pokemon_rust/src/pokemon/data/mod.rs
+++ b/pokemon_rust/src/pokemon/data/mod.rs
@@ -1,2 +1,3 @@
 pub mod movement;
 pub mod pokemon;
+pub mod status_conditions;

--- a/pokemon_rust/src/pokemon/data/movement.rs
+++ b/pokemon_rust/src/pokemon/data/movement.rs
@@ -15,6 +15,7 @@ use crate::pokemon::{
     },
     PokemonType,
     Stat,
+    StatusCondition,
 };
 
 use lazy_static::lazy_static;
@@ -218,6 +219,29 @@ lazy_static! {
             target_type: TargetType::SingleAdjacentTarget,
             multi_hit: None,
             secondary_effect: None,
+            critical_hit: false,
+        });
+
+        result.push(Move {
+            id: "FirePunch".to_string(),
+            display_name: "Fire Punch".to_string(),
+            description: "".to_string(), // TODO
+            move_type: PokemonType::Fire,
+            category: MoveCategory::Physical,
+            base_power: MovePower::Constant(75),
+            power_modifier: None,
+            accuracy: Some(100),
+            accuracy_modifier: None,
+            flags: HashSet::new(),
+            on_usage_attempt: None,
+            pp: 15,
+            priority: 0,
+            target_type: TargetType::SingleAdjacentTarget,
+            multi_hit: None,
+            secondary_effect: Some(SecondaryEffect {
+                chance: 10,
+                effect: SimpleEffect::StatusCondition(StatusCondition::Burn),
+            }),
             critical_hit: false,
         });
 

--- a/pokemon_rust/src/pokemon/data/pokemon.rs
+++ b/pokemon_rust/src/pokemon/data/pokemon.rs
@@ -607,7 +607,7 @@ lazy_static! {
                 // 21: "QuickGuard",
                 // 24: "ThunderPunch",
                 // 24: "IcePunch",
-                // 24: "FirePunch",
+                24: "FirePunch",
                 // 28: "Agility",
                 32: "MegaPunch",
                 // 36: "CloseCombat",

--- a/pokemon_rust/src/pokemon/data/status_conditions.rs
+++ b/pokemon_rust/src/pokemon/data/status_conditions.rs
@@ -1,0 +1,64 @@
+use crate::{
+    battle::backend::{BattleBackend, TypeEffectiveness},
+    pokemon::{
+        movement::{
+            Move,
+            MoveCategory,
+        },
+        SimpleStatusCondition,
+        Stat,
+    },
+};
+
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Error, Formatter},
+};
+
+pub struct StatusConditionEffect {
+    on_try_deal_damage: fn(
+        backend: &BattleBackend,
+        user: usize,
+        target: usize,
+        mov: &Move,
+        damage_dealt: usize,
+    ) -> usize,
+
+    on_turn_end: fn(backend: &mut BattleBackend, target: usize),
+}
+
+impl Debug for StatusConditionEffect {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        f.write_str("StatusConditionEffect")
+    }
+}
+
+pub fn get_status_condition_effect(
+    status_condition: SimpleStatusCondition,
+) -> StatusConditionEffect {
+    match status_condition {
+        SimpleStatusCondition::Burn => StatusConditionEffect {
+            on_try_deal_damage: |backend, _user, _target, mov, damage_dealt| {
+                if mov.category == MoveCategory::Physical {
+                    damage_dealt / 2
+                } else {
+                    damage_dealt
+                }
+            },
+            on_turn_end: |backend, target| {
+                let max_hp = backend.get_stat(target, Stat::HP) as f32;
+                let damage = (max_hp / 16.).ceil() as usize;
+
+                backend.inflict_calculated_damage(
+                    target,
+                    damage,
+                    TypeEffectiveness::Normal,
+                    false,
+                    None,
+                    false,
+                );
+            }
+        },
+        _ => todo!(),
+    }
+}

--- a/pokemon_rust/src/pokemon/data/status_conditions.rs
+++ b/pokemon_rust/src/pokemon/data/status_conditions.rs
@@ -10,13 +10,11 @@ use crate::{
     },
 };
 
-use std::{
-    collections::HashMap,
-    fmt::{Debug, Error, Formatter},
-};
+use std::fmt::{Debug, Error, Formatter};
 
+#[derive(Clone)]
 pub struct StatusConditionEffect {
-    on_try_deal_damage: fn(
+    pub on_try_deal_damage: fn(
         backend: &BattleBackend,
         user: usize,
         target: usize,
@@ -24,7 +22,7 @@ pub struct StatusConditionEffect {
         damage_dealt: usize,
     ) -> usize,
 
-    on_turn_end: fn(backend: &mut BattleBackend, target: usize),
+    pub on_turn_end: fn(backend: &mut BattleBackend, target: usize),
 }
 
 impl Debug for StatusConditionEffect {
@@ -38,7 +36,7 @@ pub fn get_status_condition_effect(
 ) -> StatusConditionEffect {
     match status_condition {
         SimpleStatusCondition::Burn => StatusConditionEffect {
-            on_try_deal_damage: |backend, _user, _target, mov, damage_dealt| {
+            on_try_deal_damage: |_backend, _user, _target, mov, damage_dealt| {
                 if mov.category == MoveCategory::Physical {
                     damage_dealt / 2
                 } else {

--- a/pokemon_rust/src/pokemon/mod.rs
+++ b/pokemon_rust/src/pokemon/mod.rs
@@ -12,7 +12,11 @@ use std::{
     time::SystemTime,
 };
 
-pub use self::data::{movement::get_all_moves, pokemon::get_all_pokemon_species};
+pub use self::data::{
+    movement::get_all_moves,
+    pokemon::get_all_pokemon_species,
+    status_conditions::{get_status_condition_effect, StatusConditionEffect},
+};
 
 /// Type effectiveness table. Every number is doubled (e.g 0.5x effectiveness
 /// is stored as 1) so that we don't need to store floats.
@@ -202,6 +206,16 @@ pub enum StatusCondition {
     Poison,
     Toxic { counter: usize },
     Sleep { remaining_turns: usize },
+}
+
+#[derive(Eq, Hash, PartialEq)]
+pub enum SimpleStatusCondition {
+    Burn,
+    Freeze,
+    Paralysis,
+    Poison,
+    Toxic,
+    Sleep,
 }
 
 #[derive(Clone, Debug)]

--- a/pokemon_rust/src/pokemon/mod.rs
+++ b/pokemon_rust/src/pokemon/mod.rs
@@ -218,6 +218,19 @@ pub enum SimpleStatusCondition {
     Sleep,
 }
 
+impl From<StatusCondition> for SimpleStatusCondition {
+    fn from(condition: StatusCondition) -> SimpleStatusCondition {
+        match condition {
+            StatusCondition::Burn => SimpleStatusCondition::Burn,
+            StatusCondition::Freeze => SimpleStatusCondition::Freeze,
+            StatusCondition::Paralysis => SimpleStatusCondition::Paralysis,
+            StatusCondition::Poison => SimpleStatusCondition::Poison,
+            StatusCondition::Toxic { .. } => SimpleStatusCondition::Toxic,
+            StatusCondition::Sleep { .. } => SimpleStatusCondition::Sleep,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum PokerusData {
     Unaffected,

--- a/pokemon_rust/src/pokemon/mod.rs
+++ b/pokemon_rust/src/pokemon/mod.rs
@@ -194,7 +194,7 @@ pub enum Gender {
     Genderless,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StatusCondition {
     Burn,
     Freeze,

--- a/pokemon_rust/src/pokemon/movement.rs
+++ b/pokemon_rust/src/pokemon/movement.rs
@@ -46,7 +46,7 @@ pub struct Move {
     pub critical_hit: bool,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MoveCategory {
     Physical,
     Special,

--- a/pokemon_rust/src/pokemon/movement.rs
+++ b/pokemon_rust/src/pokemon/movement.rs
@@ -46,7 +46,7 @@ pub struct Move {
     pub critical_hit: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum MoveCategory {
     Physical,
     Special,


### PR DESCRIPTION
This PR introduces the idea of "active effects". Active effects represent groups of functions that are called in specific moments during turn processing. Their purpose is to modularize the implementation of status conditions, avoiding the increase of hardcoded logic in the backend.

In the future, "confusion" and "flinch" might be rewritten as active effects to further improve code quality; this PR shows how the non-volatile status condition "burn" can be implemented using them.